### PR TITLE
Fix duplicate quote, duplicate menu config, and sysadmin typo

### DIFF
--- a/assets/functions/quotes.js
+++ b/assets/functions/quotes.js
@@ -29,7 +29,6 @@ document.addEventListener("DOMContentLoaded", function () {
     { text: "It does not matter how slowly you go as long as you do not stop", author: "Confucius" },
     { text: "Man cannot discover new oceans unless he has the courage to lose sight of the shore", author: "Andre Gide" },
     { text: "There is nothing noble in being superior to your fellow man; true nobility is being superior to your former self.", author: "Ernest Hemingway" },
-    { text: "There is nothing noble in being superior to your fellow man; true nobility is being superior to your former self.", author: "Ernest Hemingway" },
     { text: "Life shrinks or expands in proportion to one's courage", author: "Anais Nin" },
     { text: "The only way to make sense out of change is to plunge into it, move with it, and join the dance.", author: "Alan Watts" },
     { text: "Be Loyal to the nightmare of your choice", author: "Joseph Conrad" },

--- a/config.yml
+++ b/config.yml
@@ -10,15 +10,6 @@ pagination:
 taxonomies:
   tag: "tags"
 
-menu:
-  main:
-    - name: Posts
-      url: /posts/
-      weight: 1
-    - name: Tags
-      url: /tags/
-      weight: 2
-
 params:
   description: "RAW-TECH"
   author: "Ryan Witts"

--- a/content/posts/HardwareReadiness.md
+++ b/content/posts/HardwareReadiness.md
@@ -1,7 +1,7 @@
 ---
 title: "Windows 11 Readiness Reporting via PowerShell + Active Directory"
 date: 2025-07-03
-tags: ["sysyadmin", "tech", "powershell", "active directory"]
+tags: ["sysadmin", "tech", "powershell", "active directory"]
 summary: "How to implement a domain-wide Windows 11 readiness audit using PowerShell and Active Directory to track compatibility across all machines."
 type: post
 cover:

--- a/data/site_stats.json
+++ b/data/site_stats.json
@@ -25,7 +25,7 @@
     "powershell",
     "proxmox",
     "python",
-    "sysyadmin",
+    "sysadmin",
     "tech",
     "web development"
   ],


### PR DESCRIPTION
- Remove duplicate Hemingway quote in quotes.js
- Remove duplicate menu block from config.yml
- Fix 'sysyadmin' typo to 'sysadmin' in HardwareReadiness.md and site_stats.json